### PR TITLE
Upgrade to Jersey 1.17.1 and Jetty 8.1.14.v20131031

### DIFF
--- a/README
+++ b/README
@@ -3,7 +3,7 @@ Jersey Test Framework - Jetty 8 Module
 
 Addon for Jersey Test Framework.
 
-Jetty 8 based TestContainerFactory for Jersey 1.13.
+Jetty 8 based TestContainerFactory for Jersey 1.17.1.
 
 Usage:
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,14 +30,14 @@
 	<parent>
 		<groupId>com.sun.jersey</groupId>
 		<artifactId>jersey-test-framework</artifactId>
-		<version>1.13</version>
+		<version>1.17.1</version>
 	</parent>
 	<groupId>com.sun.jersey.jersey-test-framework</groupId>
 	<artifactId>jersey-test-framework-jetty8</artifactId>
 	<packaging>jar</packaging>
 	<name>Jersey Test Framework - Jetty 8 Module</name>
 	<properties>
-		<version.jetty>8.1.5.v20120716</version.jetty>
+		<version.jetty>8.1.14.v20131031</version.jetty>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
It's just a simple update of jersey-test-framework-jetty8 to follow latest upstream release.

pom.xml: Upgrade to Jersey 1.17.1 and Jetty 8.1.14.v20131031
